### PR TITLE
Heroku container registry login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Continuous Integration and Delivery
 on: [push]
 
 env:
-  IMAGE: docker.pkg.github.com/$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')/summarizer
+  IMAGE: docker.pkg.github.com/$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')/summarizer1
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Continuous Integration and Delivery
 on: [push]
 
 env:
-  IMAGE: docker.pkg.github.com/$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')/summarizer1
+  IMAGE: docker.pkg.github.com/$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')/summarizer
 
 jobs:
   build:
@@ -127,7 +127,7 @@ jobs:
             --file ./project/Dockerfile.prod \
             "./project"
       - name: Log in to the Heroku Container Registry
-        run: echo ${HEROKU_AUTH_TOKEN} | docker login -u _ --password-stdin  registry.heroku.com
+        run: docker login -u _ -p ${HEROKU_AUTH_TOKEN} registry.heroku.com
         env:
           HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
       - name: Push to the registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ env:
   IMAGE: docker.pkg.github.com/$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')/summarizer
 
 jobs:
-
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
@@ -98,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test]
     env:
-      HEROKU_APP_NAME: sleepy-thicket-77414
+      HEROKU_APP_NAME: mysterious-meadow-33322
       HEROKU_REGISTRY_IMAGE: registry.heroku.com/${HEROKU_APP_NAME}/summarizer
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
             --file ./project/Dockerfile.prod \
             "./project"
       - name: Log in to the Heroku Container Registry
-        run: docker login -u _ -p ${HEROKU_AUTH_TOKEN} registry.heroku.com
+        run: echo ${HEROKU_AUTH_TOKEN} | docker login -u _ --password-stdin  registry.heroku.com
         env:
           HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
       - name: Push to the registry


### PR DESCRIPTION
Running the original main.yml gives the following warning:

`Run docker login -u _ -p ${HEROKU_AUTH_TOKEN} registry.heroku.com
WARNING! Using -*** the CLI is insecure. Use --password-stdin.`

Revised line:
`run: echo ${HEROKU_AUTH_TOKEN} | docker login -u _ --password-stdin  registry.heroku.com`

does not produce the warning.

