### PR TITLE
Remove calls to os.getenv() and os.environ.get() in config.py

### DIFF
--- a/project/app/config.py
+++ b/project/app/config.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from functools import lru_cache
 
 from pydantic import AnyUrl, BaseSettings
@@ -8,9 +7,9 @@ log = logging.getLogger("uvicorn")
 
 
 class Settings(BaseSettings):
-    environment: str = os.getenv("ENVIRONMENT", "dev")
-    testing: bool = os.getenv("TESTING", 0)
-    database_url: AnyUrl = os.environ.get("DATABASE_URL")
+    environment: str = "dev"
+    testing: bool = 0
+    database_url: AnyUrl = None
 
 
 @lru_cache()


### PR DESCRIPTION
BaseSettings reads from environment vars already so no need to explicitly call os.getenv() or os.environ.get()